### PR TITLE
Matcher improvements

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -1,6 +1,75 @@
 const fuzz = require("fuzzball");
 
 /**
+ * Normalized quality/source tags for matching.
+ * Comprehensive list from scene release standards.
+ */
+const QUALITY_TAGS = [
+  // Cam sources
+  "CAM", "CAMRIP", "CAM-RIP", "HDCAM",
+  // Telesync
+  "TS", "HDTS", "TELESYNC", "PDVD", "PREDVDRIP",
+  // Workprint
+  "WP", "WORKPRINT",
+  // Telecine
+  "TC", "HDTC", "TELECINE",
+  // Pay-Per-View
+  "PPV", "PPVRIP",
+  // Screener
+  "SCR", "SCREENER", "DVDSCR", "DVDSCREENER", "BDSCR", "WEBSCREENER",
+  // Digital Distribution
+  "DDC",
+  // R5
+  "R5",
+  // DVD sources
+  "DVDRIP", "DVDMUX", "DVDR", "DVD-FULL", "FULL-RIP", "DVD-5", "DVD-9",
+  // TV/Satellite sources
+  "DSR", "DSRIP", "SATRIP", "DTHRIP", "DVBRIP", "HDTV", "PDTV", "DTVRIP", "TVRIP", "HDTVRIP",
+  // VOD
+  "VODRIP", "VODR",
+  // HC/HD-Rip
+  "HC", "HDRIP",
+  // WEBCap
+  "WEBCAP", "WEB-CAP",
+  // WEB sources
+  "WEB-DL", "WEBDL", "WEBRIP", "WEB-RIP", "WEB-DLRIP",
+  // Blu-ray sources
+  "BLURAY", "BLU-RAY", "BDRIP", "BRRIP", "BRIP", "BDR",
+  "BD25", "BD50", "BD66", "BD100", "BD5", "BD9",
+  "BDMV", "BDISO", "COMPLETE.BLURAY",
+  // Remux (high quality)
+  "REMUX",
+].map(tag => tag.toUpperCase());
+
+/**
+ * Additional technical tags to filter out when extracting release groups.
+ * These are not source types but encoding/resolution/audio indicators.
+ */
+const TECHNICAL_TAGS = [
+  // Resolution tags
+  "1080P", "720P", "2160P", "4K", "UHD", "480P", "576P",
+  // HDR variants
+  "HDR", "HDR10", "HDR10PLUS", "DOLBYVISION", "DV",
+  // Video codecs
+  "X264", "H264", "X265", "H265", "HEVC", "AVC", "XVID", "DIVX", "VP9", "AV1",
+  // Audio codecs
+  "AAC", "AC3", "DTS", "DTSHD", "DTSHDMA", "TRUEHD", "ATMOS",
+  "DDP5", "DDP2", "DDP", "DD5", "DD2", "EAC3", "FLAC", "MP3", "OPUS",
+  // Audio channels
+  "5.1", "7.1", "2.0", "1.0",
+  // Release tags
+  "INTERNAL", "REPACK", "PROPER", "LIMITED", "MULTI", "DUBBED", "SUBBED",
+  "SUBS", "RO", "EN", "EXTENDED", "UNRATED", "DIRECTORS", "CUT", "THEATRICAL",
+  // Container hints (sometimes in filename)
+  "MKV", "MP4", "AVI",
+];
+
+/**
+ * Combined list of tags to ignore when extracting release groups.
+ */
+const IGNORED_TAGS = [...QUALITY_TAGS, ...TECHNICAL_TAGS];
+
+/**
  * Extract the release group from a filename.
  * Conventionally, this is the part after the last dash (e.g., Title-GROUP.mkv)
  */
@@ -24,52 +93,14 @@ function getReleaseGroup(filename) {
     .replace(/[.\-_[\]()]/g, " ")
     .trim()
     .split(/\s+/);
-  const ignored = [
-    "REMUX",
-    "BLURAY",
-    "BDRIP",
-    "BRRIP",
-    "WEB-DL",
-    "WEBRip",
-    "WEBDL",
-    "HDRIP",
-    "DVDRIP",
-    "HDTV",
-    "PDTV",
-    "CAM",
-    "TS",
-    "TC",
-    "SCR",
-    "1080P",
-    "720P",
-    "2160P",
-    "4K",
-    "UHD",
-    "HDR",
-    "DV",
-    "X264",
-    "H264",
-    "X265",
-    "HEVC",
-    "AAC",
-    "DDP5",
-    "DDP2",
-    "DD5",
-    "AC3",
-    "DTS",
-    "INTERNAL",
-    "REPACK",
-    "PROPER",
-    "LIMITED",
-    "MULTI",
-    "SUBS",
-    "RO",
-    "EN",
-  ];
 
   for (let i = words.length - 1; i >= Math.max(0, words.length - 2); i--) {
     const word = words[i].toUpperCase();
-    if (!ignored.includes(word) && !/^\d{4}$/.test(word) && word.length >= 2) {
+    if (
+      !IGNORED_TAGS.includes(word) &&
+      !/^\d{4}$/.test(word) &&
+      word.length >= 2
+    ) {
       return word;
     }
   }
@@ -79,30 +110,30 @@ function getReleaseGroup(filename) {
 
 /**
  * Extract quality/source tags from a filename.
+ * @param {string} filename - The filename to extract tags from
+ * @returns {string[]} - Array of matched quality tags (uppercase)
  */
 function getQualityTags(filename) {
   if (!filename) return [];
-  const tags = [
-    "REMUX",
-    "BluRay",
-    "BDRip",
-    "BRRip",
-    "WEB-DL",
-    "WEBRip",
-    "WEBDL",
-    "HDRip",
-    "DVDRip",
-    "HDTV",
-    "PDTV",
-    "CAM",
-    "TS",
-    "TC",
-    "SCR",
-  ];
   const found = [];
   const normalized = filename.toUpperCase();
-  for (const tag of tags) {
-    if (normalized.includes(tag.toUpperCase())) found.push(tag.toUpperCase());
+  for (const tag of QUALITY_TAGS) {
+    if (normalized.includes(tag)) found.push(tag);
+  }
+  return found;
+}
+
+/**
+ * Extract technical tags from a filename (resolution, codec, audio, etc.)
+ * @param {string} filename - The filename to extract tags from
+ * @returns {string[]} - Array of matched technical tags (uppercase)
+ */
+function getTechnicalTags(filename) {
+  if (!filename) return [];
+  const found = [];
+  const normalized = filename.toUpperCase();
+  for (const tag of TECHNICAL_TAGS) {
+    if (normalized.includes(tag)) found.push(tag);
   }
   return found;
 }
@@ -113,20 +144,28 @@ function getQualityTags(filename) {
  *
  * Scoring (0-100 bounded):
  * - Release Group Match: +50
- * - Source Type Match: +30
- * - Title Fuzzy Similarity: 0-20 (capped, tiebreaker only)
+ * - Source Type Match: +30 (from filename or page metadata)
+ * - Technical Tags Match: +5 (resolution, codec, audio match)
+ * - Title Fuzzy Similarity: 0-15 (capped, tiebreaker only)
  *
  * @param {string} videoFilename - The video file name
  * @param {string} subtitleFilename - The subtitle file name
+ * @param {Object} [metadata] - Optional metadata from subtitle page
+ * @param {string|null} [metadata.fps] - Frame rate (e.g., "23.976")
+ * @param {string[]} [metadata.formats] - Formats (e.g., ["WEB-DL", "BLURAY"])
  * @returns {number} - Weighted score (0-100)
  */
-function calculateMatchScore(videoFilename, subtitleFilename) {
+function calculateMatchScore(videoFilename, subtitleFilename, metadata = null) {
   if (!videoFilename || !subtitleFilename) return 0;
 
   const vGroup = getReleaseGroup(videoFilename);
   const vTags = getQualityTags(videoFilename);
+  const vTechTags = getTechnicalTags(videoFilename);
   const sGroup = getReleaseGroup(subtitleFilename);
   const subNormalized = subtitleFilename.toUpperCase();
+
+  // Normalize metadata formats for comparison
+  const metadataFormats = (metadata?.formats || []).map((f) => f.toUpperCase());
 
   let score = 0;
 
@@ -139,59 +178,41 @@ function calculateMatchScore(videoFilename, subtitleFilename) {
   }
 
   // 2. Source Type Match (+30) - Secondary sync indicator
-  const hasSourceMatch = vTags.some((tag) => subNormalized.includes(tag));
-  if (hasSourceMatch) {
+  // Check both subtitle filename AND page metadata formats
+  const hasSourceMatchInFilename = vTags.some((tag) =>
+    subNormalized.includes(tag)
+  );
+  const hasSourceMatchInMetadata =
+    metadataFormats.length > 0 &&
+    vTags.some((tag) =>
+      metadataFormats.some(
+        (format) => format.includes(tag) || tag.includes(format)
+      )
+    );
+
+  if (hasSourceMatchInFilename || hasSourceMatchInMetadata) {
     score += 30;
   }
 
-  // 3. Title Fuzzy Similarity (0-20) - Tiebreaker only
-  // Cap at 20 since we already filter by IMDB ID
+  // 3. Technical Tags Match (+5) - Small bonus for matching resolution/codec/audio
+  const techMatchCount = vTechTags.filter((tag) =>
+    subNormalized.includes(tag)
+  ).length;
+  if (techMatchCount > 0) {
+    score += 5;
+  }
+
+  // 4. Title Fuzzy Similarity (0-15) - Tiebreaker only
+  // Cap at 15 since we already filter by IMDB ID
   const fuzzyScore = fuzz.token_set_ratio(
     videoFilename.toLowerCase(),
     subtitleFilename.toLowerCase()
   );
-  score += Math.min(20, Math.round(fuzzyScore * 0.2));
+  score += Math.min(15, Math.round(fuzzyScore * 0.15));
+
+  // TODO: Future enhancement - FPS matching for sync precision
 
   return Math.min(100, score);
-}
-
-/**
- * Calculate token-based similarity between two strings.
- * Uses token_set_ratio which handles word reordering and partial matches.
- * @param {string} str1 - First string
- * @param {string} str2 - Second string
- * @returns {number} - Similarity score 0-100
- */
-function tokenSimilarity(str1, str2) {
-  if (!str1 || !str2) return 0;
-  return fuzz.token_set_ratio(str1.toLowerCase(), str2.toLowerCase());
-}
-
-/**
- * Find the best matching string from a list of candidates.
- * @param {string} target - The target string to match against
- * @param {string[]} candidates - Array of candidate strings
- * @returns {{ match: string, score: number, index: number } | null}
- */
-function findBestMatch(target, candidates) {
-  if (!target || !candidates || candidates.length === 0) return null;
-
-  let bestMatch = null;
-  let bestScore = 0;
-  let bestIndex = -1;
-
-  candidates.forEach((candidate, index) => {
-    const score = tokenSimilarity(target, candidate);
-    if (score > bestScore) {
-      bestScore = score;
-      bestMatch = candidate;
-      bestIndex = index;
-    }
-  });
-
-  return bestScore > 0
-    ? { match: bestMatch, score: bestScore, index: bestIndex }
-    : null;
 }
 
 /**
@@ -267,35 +288,9 @@ function matchesEpisode(text, season, episode) {
   }
 }
 
-/**
- * Extract season and episode from various text formats.
- * @param {string} text - Text to parse
- * @returns {{ season: number, episode: number } | null}
- */
-function extractSeasonEpisode(text) {
-  if (!text) return null;
-
-  const patterns = [
-    /s(\d{1,2})e(\d{1,2})/i, // S01E05
-    /(\d{1,2})x(\d{1,2})/i, // 1x05
-    // Universal pattern for Season X Episode Y
-    /(?:season|sezon|stagione|saison|staffel|évad|κύκλος|temporada)\s*(\d+).*?(?:episode|episod|episodio|épisode|folge|epizód|επεισόδιο|episódio)\s*(\d+)/i,
-  ];
-
-  for (const pattern of patterns) {
-    const match = text.match(pattern);
-    if (match) {
-      return {
-        season: parseInt(match[1], 10),
-        episode: parseInt(match[2], 10),
-      };
-    }
-  }
-
-  return null;
-}
-
 module.exports = {
   matchesEpisode,
   calculateMatchScore,
+  getQualityTags,
+  getReleaseGroup,
 };

--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -76,6 +76,30 @@ class SubsRoRateLimiter {
   }
 
   /**
+   * Fetch a page (HTML) with rate limiting.
+   * Uses the search queue to avoid overwhelming the server.
+   * @param {string} url - Page URL to fetch
+   * @returns {Promise<string>} - HTML content
+   */
+  async fetchPage(url) {
+    this.lastUsed = Date.now();
+    return new Promise((resolve, reject) => {
+      this.queues.search.queue.push({
+        url,
+        options: {
+          headers: {
+            "User-Agent": "Mozilla/5.0 (compatible; StremioSubsRo/1.0)",
+            Accept: "text/html,application/xhtml+xml",
+          },
+        },
+        resolve,
+        reject,
+        retries: 0,
+      });
+    });
+  }
+
+  /**
    * Process search queue (sequential, 1/sec)
    */
   async processSearchQueue() {
@@ -127,7 +151,7 @@ class SubsRoRateLimiter {
       const response = await axios.get(url, {
         ...options,
         timeout: this.timeout,
-        maxContentLength: 10 * 1024 * 1024,
+        maxContentLength: 15 * 1024 * 1024,
       });
 
       resolve(response.data);

--- a/lib/subsro.js
+++ b/lib/subsro.js
@@ -1,5 +1,9 @@
 const { getLimiter } = require("./rateLimiter");
 
+// Cache for page metadata to avoid repeated scraping
+const PAGE_METADATA_CACHE = new Map();
+const PAGE_METADATA_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
 class SubsRoClient {
   constructor(apiKey) {
     this.apiKey = apiKey;
@@ -23,6 +27,81 @@ class SubsRoClient {
       // Errors are already logged explicitly by RateLimiter
       return [];
     }
+  }
+
+  /**
+   * Fetch and parse metadata from a subtitle's page.
+   * Extracts FPS and formats from the HTML.
+   *
+   * @param {string} pageUrl - The subtitle page URL (e.g., https://subs.ro/subtitrare/movie-name/12345)
+   * @returns {Promise<{fps: string|null, formats: string[]}>}
+   */
+  async getSubtitleMetadata(pageUrl) {
+    if (!pageUrl) return { fps: null, formats: [] };
+
+    // Check cache first
+    const cached = PAGE_METADATA_CACHE.get(pageUrl);
+    if (cached && Date.now() - cached.timestamp < PAGE_METADATA_TTL) {
+      return cached.data;
+    }
+
+    try {
+      const limiter = getLimiter(this.apiKey);
+      const html = await limiter.fetchPage(pageUrl);
+
+      const metadata = this._parsePageMetadata(html);
+
+      // Cache the result
+      PAGE_METADATA_CACHE.set(pageUrl, {
+        data: metadata,
+        timestamp: Date.now(),
+      });
+
+      return metadata;
+    } catch (error) {
+      // Silently fail - metadata is optional enhancement
+      return { fps: null, formats: [] };
+    }
+  }
+
+  /**
+   * Parse FPS and formats from subtitle page HTML.
+   * @param {string} html - The page HTML content
+   * @returns {{fps: string|null, formats: string[]}}
+   */
+  _parsePageMetadata(html) {
+    const result = { fps: null, formats: [] };
+
+    if (!html) return result;
+
+    // Extract FPS from:
+    // <div>
+    //   <p class="font-semibold text-gray-700">FPS</p>
+    //   <p class="text-gray-600">23.976</p>
+    // </div>
+    const fpsMatch = html.match(/<p[^>]*>FPS<\/p>\s*<p[^>]*>([0-9.]+)<\/p>/i);
+    if (fpsMatch) {
+      result.fps = fpsMatch[1];
+    }
+
+    // Extract formats from:
+    // <div class="text-xl font-bold text-gray-700">
+    //   WEB-DL / DVDRIP / BluRay
+    // </div>
+    // <div class="text-sm text-gray-600">Format</div>
+    const formatMatch = html.match(
+      /<div[^>]*text-xl[^>]*font-bold[^>]*>\s*([^<]+)\s*<\/div>\s*<div[^>]*>Format<\/div>/i
+    );
+    if (formatMatch) {
+      // Parse formats like "WEB-DL / DVDRIP / BluRay"
+      const formatStr = formatMatch[1].trim();
+      result.formats = formatStr
+        .split(/\s*\/\s*/)
+        .map((f) => f.trim().toUpperCase())
+        .filter((f) => f.length > 0);
+    }
+
+    return result;
   }
 
   async validate() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stremio-subs-ro",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stremio-subs-ro",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.10",


### PR DESCRIPTION
- scrape subs ro metadata if unable to retrieve release groups from subtitle name
- added more release groups, normalized tags and use tech tags as a scoring mechanism
- removed unused matcher methods

Link for the release groups/formats: [Wiki-link](https://en.wikipedia.org/wiki/Pirated_movie_release_types)